### PR TITLE
Fixed SyntaxError for print app

### DIFF
--- a/BackspaceBack.py
+++ b/BackspaceBack.py
@@ -11,7 +11,7 @@ from gi.repository import GObject, Nautilus, Gtk, Gio, GLib
 
 def ok():
     app = Gtk.Application.get_default()
-    print app.set_accels_for_action( "win.up", ["BackSpace"] )
+    app.set_accels_for_action( "win.up", ["BackSpace"] )
     #print app.get_actions_for_accel("BackSpace")
     #print app.get_actions_for_accel("<alt>Up")
 


### PR DESCRIPTION
Fixed the SyntaxError when printing the app.

The error was:
```
   File "/home/arman/.local/share/nautilus-python/extensions/BackspaceBack.py", line 14
     print app.set_accels_for_action( "win.up", ["BackSpace"] )
             ^
 SyntaxError: invalid syntax
```