### PR TITLE
Add Install Script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
-*Nautilus Backspace*
+# Backspace-Up
 -----------------------
 Brings back the Backspace shortcut to Nautilus
 
-Installation
 -----------------------
-1) Install [Nautilus Python](https://wiki.gnome.org/Projects/NautilusPython) (`apt-get install python-nautilus` in Debian-based distributions)
- 
-2) Download `Backspace-Back.py` and put it here: `.local/share/nautilus-python/extensions/`
+## Dependencies
 
-(you might have to create this directory first)
+- python-nautilus or nautilus-python package [will install automatically]
 
-3) Restart Nautilus (`killall nautilus`)
+
+## Installation
+
+```shell
+wget -qO- https://raw.githubusercontent.com/7aman/backspace-up/master/install.sh | bash
+```

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Backspace-Up
------------------------
+
 Brings back the Backspace shortcut to Nautilus
 
------------------------
+
 ## Dependencies
 
 - `python-nautilus` or `nautilus-python` package [will be installed automatically]

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ Brings back the Backspace shortcut to Nautilus
 -----------------------
 ## Dependencies
 
-- python-nautilus or nautilus-python package [will install automatically]
+- `python-nautilus` or `nautilus-python` package [will be installed automatically]
 
 
 ## Installation
 
 ```shell
-wget -qO- https://raw.githubusercontent.com/7aman/backspace-up/master/install.sh | bash
+wget -qO- https://raw.githubusercontent.com/riclc/nautilus_backspace/master/install.sh | bash
 ```

--- a/backspace-up.py
+++ b/backspace-up.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
 # by Ricardo Lenz, 2016-jun
@@ -12,8 +12,8 @@ from gi.repository import GObject, Nautilus, Gtk, Gio, GLib
 def ok():
     app = Gtk.Application.get_default()
     app.set_accels_for_action( "win.up", ["BackSpace"] )
-    #print app.get_actions_for_accel("BackSpace")
-    #print app.get_actions_for_accel("<alt>Up")
+    #print(app.get_actions_for_accel("BackSpace"))
+    #print(app.get_actions_for_accel("<alt>Up"))
 
 
 class BackspaceBack(GObject.GObject, Nautilus.LocationWidgetProvider):

--- a/install.sh
+++ b/install.sh
@@ -35,7 +35,7 @@ rm -f ~/.local/share/nautilus-python/extensions/BackspaceBack.py
 
 # Download and install the extension
 echo "Downloading newest version..."
-wget --show-progress -q -O ~/.local/share/nautilus-python/extensions/backspace-up.py https://raw.githubusercontent.com/7aman/backspace-up/master/backspace-up.py
+wget --show-progress -q -O ~/.local/share/nautilus-python/extensions/backspace-up.py https://raw.githubusercontent.com/riclc/nautilus_backspace/master/backspace-up.py
 
 # Restart nautilus
 echo "Restarting nautilus..."

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Install python-nautilus
+echo "Installing python-nautilus..."
+if type "pacman" > /dev/null 2>&1
+then
+    sudo pacman -S --noconfirm python-nautilus
+elif type "apt-get" > /dev/null 2>&1
+then
+    installed=`apt list --installed python-nautilus -qq 2> /dev/null`
+    if [ -z "$installed" ]
+    then
+        sudo apt-get install -y python-nautilus
+    else
+        echo "python-nautilus is already installed."
+    fi
+elif type "dnf" > /dev/null 2>&1
+then
+    installed=`dnf list --installed nautilus-python 2> /dev/null`
+    if [ -z "$installed" ]
+    then
+        sudo dnf install -y nautilus-python
+    else
+        echo "nautilus-python is already installed."
+    fi
+else
+    echo "Failed to find python-nautilus, please install it manually."
+fi
+
+# Remove previous version and setup folder
+echo "Removing previous version (if found)..."
+mkdir -p ~/.local/share/nautilus-python/extensions
+rm -f ~/.local/share/nautilus-python/extensions/backspace-up.py
+rm -f ~/.local/share/nautilus-python/extensions/BackspaceBack.py
+
+# Download and install the extension
+echo "Downloading newest version..."
+wget --show-progress -q -O ~/.local/share/nautilus-python/extensions/backspace-up.py https://raw.githubusercontent.com/7aman/backspace-up/master/backspace-up.py
+
+# Restart nautilus
+echo "Restarting nautilus..."
+sudo killall nautilus
+
+echo "Installation Complete"


### PR DESCRIPTION
This PR adds install script that will automatically install `python-nautilus` dependency.  
Also to be more accurate, name of script is changed to `backspace-up` because hitting backspace is not actually going back. It goes up one directory [parent directory].  
While this PR is getting merged, you can use my master branch:  
```shell
wget -qO- https://raw.githubusercontent.com/7aman/backspace-up/master/install.sh | bash
```
